### PR TITLE
Mitigate player-swap mismatch teleport crash

### DIFF
--- a/src/main/java/no2/worldthreader/common/dimension_change/DimensionChangeHelper.java
+++ b/src/main/java/no2/worldthreader/common/dimension_change/DimensionChangeHelper.java
@@ -45,19 +45,21 @@ public class DimensionChangeHelper {
             teleportTransition = teleportedEntityInfo.entityTransition();
         } else {
             ((ServerWorldExtended) destination).worldthreader$setArrivingEntityInfo(teleportedEntityInfo);
+            try {
+                //Server players might be able to move after starting to teleport (packets being sent from the client, sent
+                // before client knows about changing dimensions) This is why the entry position of the portal processor
+                // must be updated to the original position.
+                //Furthermore, using oldEntityObject.portalProcessor is not safe, as it might be null, since a moved player
+                // will also be ticked (the network connection tick ticks the serverside player entity), removing the portal
+                // processor if the player is no longer intersecting the portal.
+                // Related to https://github.com/2No2Name/worldthreader/issues/12
+                PortalProcessor portalProcessor = Objects.requireNonNull(teleportedEntityInfo.portalProcessor());
+                portalProcessor.updateEntryPosition(teleportedEntityInfo.portalProcessorPos());
 
-            //Server players might be able to move after starting to teleport (packets being sent from the client, sent
-            // before client knows about changing dimensions) This is why the entry position of the portal processor
-            // must be updated to the original position.
-            //Furthermore, using oldEntityObject.portalProcessor is not safe, as it might be null, since a moved player
-            // will also be ticked (the network connection tick ticks the serverside player entity), removing the portal
-            // processor if the player is no longer intersecting the portal.
-            // Related to https://github.com/2No2Name/worldthreader/issues/12
-            PortalProcessor portalProcessor = Objects.requireNonNull(teleportedEntityInfo.portalProcessor());
-            portalProcessor.updateEntryPosition(teleportedEntityInfo.portalProcessorPos());
-
-            teleportTransition = portalProcessor.getPortalDestination(source, oldEntityObject);
-            ((ServerWorldExtended) destination).worldthreader$setArrivingEntityInfo(previous);
+                teleportTransition = portalProcessor.getPortalDestination(source, oldEntityObject);
+            } finally {
+                ((ServerWorldExtended) destination).worldthreader$setArrivingEntityInfo(previous);
+            }
         }
 
         if (teleportTransition == null) {
@@ -77,16 +79,19 @@ public class DimensionChangeHelper {
         TeleportedEntityInfo previous = ((ServerWorldExtended) destination).worldthreader$arrivingEntityInfo();
         ((ServerWorldExtended) destination).worldthreader$setArrivingEntityInfo(teleportedEntityInfo);
         Entity newEntity;
-        if (oldEntityObject instanceof ServerPlayer) {
-            //ServerPlayer teleportation code is mostly separate from normal entity teleportation code, both in vanilla and worldthreader.
-            //This should only be called when the player is a passenger. Normal player teleportation happens outside the multithreaded part of the tick.
-            //Heavily modified method, essentially split into departure and arrival
-            newEntity = oldEntityObject.teleport(teleportTransition);
-        } else {
-            //Heavily modified method, essentially split into departure and arrival
-            newEntity = oldEntityObject.teleportCrossDimension(source, destination, teleportTransition);
+        try {
+            if (oldEntityObject instanceof ServerPlayer) {
+                //ServerPlayer teleportation code is mostly separate from normal entity teleportation code, both in vanilla and worldthreader.
+                //This should only be called when the player is a passenger. Normal player teleportation happens outside the multithreaded part of the tick.
+                //Heavily modified method, essentially split into departure and arrival
+                newEntity = oldEntityObject.teleport(teleportTransition);
+            } else {
+                //Heavily modified method, essentially split into departure and arrival
+                newEntity = oldEntityObject.teleportCrossDimension(source, destination, teleportTransition);
+            }
+        } finally {
+            ((ServerWorldExtended) destination).worldthreader$setArrivingEntityInfo(previous);
         }
-        ((ServerWorldExtended) destination).worldthreader$setArrivingEntityInfo(previous);
 
         if (newEntity == null) {
             throw new IllegalStateException("Worldthreader: Entity could not be placed after crossing dimensions: " + oldEntityObject);

--- a/src/main/java/no2/worldthreader/mixin/dimension_change/ServerLevelMixin.java
+++ b/src/main/java/no2/worldthreader/mixin/dimension_change/ServerLevelMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.storage.WritableLevelData;
+import no2.worldthreader.WorldThreaderMod;
 import no2.worldthreader.common.WorldThreaderTickPhase;
 import no2.worldthreader.common.dimension_change.DimensionChangeHelper;
 import no2.worldthreader.common.dimension_change.TeleportedEntityInfo;
@@ -61,6 +62,11 @@ public abstract class ServerLevelMixin extends Level implements ServerWorldExten
                     try {
                         DimensionChangeHelper.nonPassengerArriveInWorld(teleportedEntity, teleportedEntity.oldEntityObject(), (ServerLevel) (Object) this, (ServerLevel) teleportedEntity.oldEntityObject().level());
                     } catch (Exception e) {
+                        if (worldthreader$isRecoverablePlayerSwapFailure(e)) {
+                            ((ServerWorldExtended) teleportedEntity.oldEntityObject().level()).worldthreader$receiveFailedTeleport(teleportedEntity);
+                            WorldThreaderMod.LOGGER.error("Worldthreader: Recovering failed teleport due to player swap mismatch. Entity={} targetDimension={}", teleportedEntity, this.dimension(), e);
+                            continue;
+                        }
                         throw new IllegalStateException("Worldthreader: Failed to receive teleported entity: " + teleportedEntity + " in dimension " + this.dimension() + "!", e);
                     }
                 }
@@ -117,5 +123,17 @@ public abstract class ServerLevelMixin extends Level implements ServerWorldExten
     @Override
     public void worldthreader$setTickPhase(WorldThreaderTickPhase tickPhase) {
         this.tickPhase = tickPhase;
+    }
+
+    @Unique
+    private static boolean worldthreader$isRecoverablePlayerSwapFailure(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            String message = current.getMessage();
+            if (message != null && (message.contains("Players not matching before player swap")
+                    || message.contains("Player swapping is already happening"))) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This PR mitigates a server crash path during cross dimension teleport arrival where Worldthreader throws from player instance swap consistency checks.

In the reported case, arrival processing hits:
- `Worldthreader: Failed to receive teleported entity ...`
- cause: `IllegalArgumentException: Players not matching before player swap.`

Instead of hard-crashing the world thread, this change routes that specific failure into the existing failed teleport recovery flow.

## What changed
1. **Recoverable handling for swap-mismatch failures during receive-teleports**
- In `ServerLevelMixin#worldthreader$finishReceivingTeleportedEntities`, detect known swap mismatch errors (`Players not matching before player swap` / `Player swapping is already happening`).
- Queue the teleport as failed via `worldthreader$receiveFailedTeleport(...)` and continue processing, rather than rethrowing and crashing the server thread.

2. **Arrival context cleanup hardening**
- In `DimensionChangeHelper`, wrap arriving-entity context updates in `try/finally` around:
  - portal destination lookup
  - `arriveIntoWorld(...)`
- Ensures `worldthreader$arrivingEntityInfo` is always restored even if arrival throws.

## Scope
- This is a **mitigation** of this crash, I do not know the root cause, or how we might fix it. It may be an incompatibility on my setup.

## Reference
- Refs #42
